### PR TITLE
bugfix(ps-testsuite): Testsuite can not decode VAU traffic

### DIFF
--- a/ps-testsuite/tiger.yaml
+++ b/ps-testsuite/tiger.yaml
@@ -1,7 +1,6 @@
 tigerProxy:
   trafficEndpoints: ["http://tiger-proxy:8080"] # admin port of tiger-proxy
-  activateRbelParsingFor:
-    - epa3-vau
+  activateEpa3VauAnalysis: true
   fileSaveInfo.writeToFile: true
   adminPort: 8124
 


### PR DESCRIPTION
bugfix(ps-testsuite): Testsuite can not decode VAU traffic leading to false negative testcases.

PS-Testsuite use old tigerProxy Dependency, but docker compose use new TigerProxy Version. Because of the old Dependency, the PS-Testsuite must use the old configuration parameter for Epa3Vau decoding.

Without the old parameter the Testsuite cant decode the inner VAU traffic. Leading to failed testcases because of failed validation of inner objects in the (undecoded) VAU traffic.